### PR TITLE
Missing dependency for jetson nano

### DIFF
--- a/buildAndPackageOpenCV.sh
+++ b/buildAndPackageOpenCV.sh
@@ -74,6 +74,7 @@ cd $WHEREAMI
 # sudo apt-get install libgl1 libglvnd-dev
  
 sudo apt-get install -y \
+    libcurl4 \
     cmake \
     libavcodec-dev \
     libavformat-dev \


### PR DESCRIPTION
Add cmake depends on libcurl4 that isn't installed on Jetpack 4.2 for jetson nano